### PR TITLE
ci: Automatically build for new pushes/pull requests.

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: ['**'] # Run workflows for pull requests to *any* branch
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@25
+
+      - name: Build release
+        run: nix develop --command make


### PR DESCRIPTION
This should hopefully just build the code using `make` everytime somebody commits to `main`, or if a pull request is opened.

Dependencies managed using Nix :sunglasses: 