### PR TITLE
ci: Speed up builds by not building `coq-lsp`.

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,4 +19,5 @@ jobs:
         uses: cachix/install-nix-action@v22
 
       - name: Build release
-        run: nix develop --command make
+        # The `--impure` flag lets the `devShell` read environment variables (e.g. $CI)
+        run: nix develop --impure --command make

--- a/flake.nix
+++ b/flake.nix
@@ -58,16 +58,8 @@
           pkgs.coq.ocamlPackages.ocaml
           pkgs.coq.ocamlPackages.dune_3
           coq-quantumlib
-          coq-lsp
-        ];
-        propagatedBuildInputs = [ pkgs.coqPackages.serapi ]
-          ++ (with pkgs.coq.ocamlPackages; [
-            camlp-streams
-            dune-build-info
-            menhir
-            uri
-            yojson
-          ]);
+        ] ++ pkgs.lib.optional (builtins.getEnv "CI" != "true")
+          coq-lsp; # Don't build the LSP in GitHub Action
       };
     };
 }


### PR DESCRIPTION
In GitHub Actions, the `$CI` variable is automatically set, so we should not include `coq-lsp` in our `devShell`.