### PR TITLE
refactor: Simplify `block_decomp`, rename other lemmas.

### DIFF
--- a/ControlledUnitaries.v
+++ b/ControlledUnitaries.v
@@ -80,7 +80,7 @@ assert (prod_decomp_1 : forall (w : Vector 2), WF_Matrix w -> U × (I 2 ⊗ Q) �
     rewrite U_beta at 1. rewrite U_beta_p at 1.
     lma'.
 }
-destruct (@block_decomp_general 2 U) as [P00 [P01 [P10 [P11 [WF_P00 [WF_P01 [WF_P10 [WF_P11 U_block_decomp]]]]]]]]. lia.
+destruct (@block_decomp 2 U) as [P00 [P01 [P10 [P11 [WF_P00 [WF_P01 [WF_P10 [WF_P11 U_block_decomp]]]]]]]].
 apply U_unitary.
 assert (prod_decomp_2: forall (w : Vector 2), WF_Matrix w -> U × (I 2 ⊗ Q) × (∣0⟩ ⊗ w) = ∣0⟩ ⊗ (P00 × Q × w) .+ ∣1⟩ ⊗ (P10 × Q × w)).
 {
@@ -189,7 +189,7 @@ assert (I_4_block_decomp: I 4 = ∣0⟩⟨0∣ ⊗ I 2 .+ ∣0⟩⟨1∣ ⊗ Zer
 assert (equal_blocks: (P00) † × P00 = I 2 /\ (Zero (m:= 2) (n:=2)) = (Zero (m:= 2) (n:=2)) 
 /\ (Zero (m:= 2) (n:=2)) = (Zero (m:= 2) (n:=2)) /\ (P11) † × P11 = I 2).
 {
-    apply block_equalities_general with (U := (U) † × U) (V := I 4).
+    apply block_equalities with (U := (U) † × U) (V := I 4).
     lia.
     1,2,3,4,5,6,7,8: solve_WF_matrix.
     1,2: assumption.

--- a/GateHelpers.v
+++ b/GateHelpers.v
@@ -641,8 +641,8 @@ abgate U = ∣0⟩⟨0∣ ⊗ TL .+ ∣0⟩⟨1∣ ⊗ TR .+ ∣1⟩⟨1∣ ⊗ 
 Proof.
 intros U U_unitary zeropassthrough.
 destruct zeropassthrough as [y [WF_y zeropassthrough]].
-destruct (@block_decomp_general 2 U) as [TL [TR [BL [BR [WF_TL [WF_TR [WF_BL [WF_BR decomp]]]]]]]].
-lia. apply U_unitary.
+destruct (@block_decomp 2 U) as [TL [TR [BL [BR [WF_TL [WF_TR [WF_BL [WF_BR decomp]]]]]]]].
+apply U_unitary.
 exists (TL ⊗ I 2), (TR ⊗ I 2), (BR ⊗ I 2).
 split. solve_WF_matrix.
 split. solve_WF_matrix.
@@ -1265,7 +1265,7 @@ assert (WF_BL_block: WF_Matrix ((TR0) † × TL0)). solve_WF_matrix.
 assert (WF_BR_block: WF_Matrix ((TR0) † × TR0 .+ (BR0) † × BR0)). solve_WF_matrix.
 assert (self_eq: (abgate U) † × abgate U = (abgate U) † × abgate U). reflexivity.
 assert (neq40: 4%nat <> 0%nat). lia.
-assert (block_eq:= @block_equalities_general 4%nat ((abgate U) † × abgate U) ((abgate U) † × abgate U) 
+assert (block_eq:= @block_equalities 4%nat ((abgate U) † × abgate U) ((abgate U) † × abgate U) 
 ((TL0) † × TL0) ((TL0) † × TR0) ((TR0) † × TL0) ((TR0) † × TR0 .+ (BR0) † × BR0) (I 4) Zero Zero (I 4) neq40 
 WF_TL0_inv WF_TR_block WF_BL_block WF_BR_block
 (@WF_I 4) (@WF_Zero 4 4) (@WF_Zero 4 4) (@WF_I 4) block_mult abU_inv self_eq).

--- a/Main.v
+++ b/Main.v
@@ -36,7 +36,7 @@ Proof.
         U = ∣0⟩⟨0∣ ⊗ V00 .+ ∣0⟩⟨1∣ ⊗ V01 .+ ∣1⟩⟨0∣ ⊗ V10 .+ ∣1⟩⟨1∣ ⊗ V11
       ).
       {
-        apply block_decomp_general; auto.
+        apply block_decomp.
         destruct Unitary_U; assumption.
       }
       destruct block_matrices_U as [V00 [V01 [V10 [V11 block_matrices_U]]]].
@@ -86,7 +86,7 @@ Proof.
           reflexivity.
       }
       rewrite UW, WU in H; clear UW WU W_eq_blocks.
-      apply (@block_equalities_general
+      apply (@block_equalities
         4%nat
         (∣0⟩⟨0∣ ⊗ (u0 .* V00) .+ ∣0⟩⟨1∣ ⊗ (u1 .* V01) .+ ∣1⟩⟨0∣ ⊗ (u0 .* V10) .+ ∣1⟩⟨1∣ ⊗ (u1 .* V11))
         (∣0⟩⟨0∣ ⊗ (u0 .* V00) .+ ∣0⟩⟨1∣ ⊗ (u0 .* V01) .+ ∣1⟩⟨0∣ ⊗ (u1 .* V10) .+ ∣1⟩⟨1∣ ⊗ (u1 .* V11))
@@ -158,7 +158,7 @@ Proof.
         repeat rewrite Mplus_0_l in Unitary_U.
         repeat rewrite Mplus_0_r in Unitary_U.
         apply (
-        @block_equalities_general
+        @block_equalities
         4%nat
         (∣0⟩⟨0∣ ⊗ ((V00) † × V00) .+ ∣0⟩⟨1∣ ⊗ Zero .+ ∣1⟩⟨0∣ ⊗ Zero .+ ∣1⟩⟨1∣ ⊗ ((V11) † × V11))
         (∣0⟩⟨0∣ ⊗ I 4 .+ ∣0⟩⟨1∣ ⊗ Zero .+ ∣1⟩⟨0∣ ⊗ Zero .+ ∣1⟩⟨1∣ ⊗ I 4)

--- a/MatrixHelpers.v
+++ b/MatrixHelpers.v
@@ -640,7 +640,7 @@ intros.
 lca.
 Qed.
 
-Lemma block_equalities_general {n}: forall (U V: Square (n+n)) (P00 P01 P10 P11 Q00 Q01 Q10 Q11: Square n),
+Lemma block_equalities {n}: forall (U V: Square (n+n)) (P00 P01 P10 P11 Q00 Q01 Q10 Q11: Square n),
 n <> 0%nat ->  
 WF_Matrix P00 -> WF_Matrix P01 -> WF_Matrix P10 -> WF_Matrix P11 ->
 WF_Matrix Q00 -> WF_Matrix Q01 -> WF_Matrix Q10 -> WF_Matrix Q11 ->
@@ -1184,12 +1184,25 @@ rewrite <- Cconj_0.
 apply Cconj_simplify. do 2 rewrite Cconj_involutive. assumption.
 Qed.
 
-Lemma block_decomp_general {n}: forall (U: Square (2*n)), n <> 0%nat -> WF_Matrix U -> 
+Lemma block_decomp {n}: forall (U: Square (2*n)), WF_Matrix U ->
 exists (TL TR BL BR : Square n), 
 WF_Matrix TL /\ WF_Matrix TR /\ WF_Matrix BL /\ WF_Matrix BR /\
 U = ∣0⟩⟨0∣ ⊗ TL .+ ∣0⟩⟨1∣ ⊗ TR .+ ∣1⟩⟨0∣ ⊗ BL .+ ∣1⟩⟨1∣ ⊗ BR.
 Proof.
-intros U nn0 WF_U.
+intros U WF_U.
+destruct (Nat.eq_dec n 0%nat) as [n0 | nn0].
+{
+  exists Zero, Zero, Zero, Zero.
+  split. apply WF_Zero.
+  split. apply WF_Zero.
+  split. apply WF_Zero.
+  split. apply WF_Zero.
+  Msimpl.
+  apply WF0_Zero.
+  unfold WF_Matrix in WF_U.
+  rewrite n0 in WF_U.
+  assumption.
+}
 set (TL := (fun x y => if (x <? n) && (y <? n) then U x y else 0 ): Square n).
 assert (WF_TL: WF_Matrix TL).
 {

--- a/OtherProperties.v
+++ b/OtherProperties.v
@@ -167,8 +167,7 @@ do 2 rewrite Mplus_0_r in V3_way1.
 do 2 rewrite Mplus_assoc in V3_way1. rewrite Mplus_comm with (A:= ∣1⟩⟨1∣
 ⊗ ((V2) † × (I 2 ⊗ (P1) †) × U1 × (V4) †)) in V3_way1.
 repeat rewrite <- Mplus_assoc in V3_way1.
-assert (ne20: 2%nat <> 0%nat). lia.
-assert (v3_decomp:= @block_decomp_general 2 V3 ne20 WF_v3).
+assert (v3_decomp:= @block_decomp 2 V3 WF_v3).
 destruct v3_decomp as [Q00 [Q01 [Q10 [Q11 [WF_Q00 [WF_Q01 [WF_Q10 [WF_Q11 v3_decomp]]]]]]]].
 assert (V3_way2: acgate V3 = swapbc × abgate V3 × swapbc). unfold acgate. reflexivity.
 unfold abgate in V3_way2.
@@ -184,7 +183,7 @@ rewrite kron_assoc in V3_way2. 2,3,4: solve_WF_matrix.
 rewrite kron_assoc in V3_way2. 2,3,4: solve_WF_matrix.
 rewrite kron_assoc in V3_way2. 2,3,4: solve_WF_matrix.
 rewrite kron_assoc in V3_way2. 2,3,4: solve_WF_matrix.
-assert (block_eq := @block_equalities_general 4 (acgate V3) (acgate V3)
+assert (block_eq := @block_equalities 4 (acgate V3) (acgate V3)
 ((V2) † × (I 2 ⊗ (P0) †) × U0 × (V4) †) (@Zero 4 4) (@Zero 4 4) ((V2) † × (I 2 ⊗ (P1) †) × U1 × (V4) †)
 (I 2 ⊗ Q00) (I 2 ⊗ Q01) (I 2 ⊗ Q10) (I 2 ⊗ Q11)).
 assert (eq: (V2) † × (I 2 ⊗ (P0) †) × U0 × (V4) † = I 2 ⊗ Q00 /\
@@ -235,7 +234,7 @@ repeat rewrite Mmult_0_r in block_unit.
 repeat rewrite Mmult_0_l in block_unit.
 repeat rewrite Mplus_0_r in block_unit.
 repeat rewrite Mplus_0_l in block_unit.
-assert (block_eq_2 := @block_equalities_general 2 (∣0⟩⟨0∣ ⊗ ((Q00) † × Q00) .+ ∣0⟩⟨1∣ ⊗ Zero .+ ∣1⟩⟨0∣ ⊗ Zero
+assert (block_eq_2 := @block_equalities 2 (∣0⟩⟨0∣ ⊗ ((Q00) † × Q00) .+ ∣0⟩⟨1∣ ⊗ Zero .+ ∣1⟩⟨0∣ ⊗ Zero
 .+ ∣1⟩⟨1∣ ⊗ ((Q11) † × Q11)) (∣0⟩⟨0∣ ⊗ I 2 .+ ∣0⟩⟨1∣ ⊗ Zero .+ ∣1⟩⟨0∣ ⊗ Zero .+ ∣1⟩⟨1∣ ⊗ I 2)
 ((Q00) † × Q00) (Zero) (Zero) ((Q11) † × Q11) (I 2) (Zero) (Zero) (I 2)).
 assert (unit_eq: (Q00) † × Q00 = I 2 /\

--- a/UnitaryMatrices.v
+++ b/UnitaryMatrices.v
@@ -423,7 +423,7 @@ assert (block_decomp: ∣0⟩⟨0∣ ⊗ (P00 × P00†) .+ ∣0⟩⟨1∣ ⊗ (
 clear V_unitary Vadj_unitary lr_mult rl_mult.
 assert (P00_decomp: P00 × P00† = P00† × P00 .+ P10† × P10).
 {
-    apply block_equalities_general with (P00:= P00 × (P00) †) (P01 := P00 × (P10) †) (P10:= P10 × (P00) †) (P11 := P10 × (P10) † .+ P11 × (P11) †)
+    apply block_equalities with (P00:= P00 × (P00) †) (P01 := P00 × (P10) †) (P10:= P10 × (P00) †) (P11 := P10 × (P10) † .+ P11 × (P11) †)
     (Q00:= (P00) † × P00 .+ (P10) † × P10) (Q01 := (P10) † × P11) (Q10:= (P11) † × P10) (Q11 := (P11) † × P11) in block_decomp.
     2: lia.
     2,3,4,5,6,7,8,9,10,11: solve_WF_matrix.


### PR DESCRIPTION
This PR serves to remove the `n <> 0` case from `block_decomp`, to make it easier to use when proving other lemmas. It also removes the `_general` suffix from a few lemmas.