### PR TITLE
State and prove M3.3.

### DIFF
--- a/AlgebraHelpers.v
+++ b/AlgebraHelpers.v
@@ -2,6 +2,16 @@ Require Import QuantumLib.Complex.
 (* @Kyle: this Matrix dependency is for just 1 thing. Maybe better to rewrite the sub_mul_mod
 proof in here *)
 Require Import QuantumLib.Matrix.
+
+Lemma Cmult_nonzero : forall (a b : C), a <> C0 -> b <> C0 -> a * b <> C0.
+Proof.
+  intros.
+  intro.
+  contradict H0.
+  apply (Cmult_cancel_l a); auto.
+  rewrite H1; lca.
+Qed.
+
 Lemma conj_mult_re_is_nonneg: forall (a: C),
 Re (a^* * a) >= 0.
 Proof.

--- a/ControlledUnitaries.v
+++ b/ControlledUnitaries.v
@@ -80,7 +80,7 @@ assert (prod_decomp_1 : forall (w : Vector 2), WF_Matrix w -> U × (I 2 ⊗ Q) �
     rewrite U_beta at 1. rewrite U_beta_p at 1.
     lma'.
 }
-destruct (@block_decomp_general 2 U) as [P00 [P01 [P10 [P11 [WF_P00 [WF_P01 [WF_P10 [WF_P11 U_block_decomp]]]]]]]]. lia.
+destruct (@block_decomp 2 U) as [P00 [P01 [P10 [P11 [WF_P00 [WF_P01 [WF_P10 [WF_P11 U_block_decomp]]]]]]]].
 apply U_unitary.
 assert (prod_decomp_2: forall (w : Vector 2), WF_Matrix w -> U × (I 2 ⊗ Q) × (∣0⟩ ⊗ w) = ∣0⟩ ⊗ (P00 × Q × w) .+ ∣1⟩ ⊗ (P10 × Q × w)).
 {
@@ -189,7 +189,7 @@ assert (I_4_block_decomp: I 4 = ∣0⟩⟨0∣ ⊗ I 2 .+ ∣0⟩⟨1∣ ⊗ Zer
 assert (equal_blocks: (P00) † × P00 = I 2 /\ (Zero (m:= 2) (n:=2)) = (Zero (m:= 2) (n:=2)) 
 /\ (Zero (m:= 2) (n:=2)) = (Zero (m:= 2) (n:=2)) /\ (P11) † × P11 = I 2).
 {
-    apply block_equalities_general with (U := (U) † × U) (V := I 4).
+    apply block_equalities with (U := (U) † × U) (V := I 4).
     lia.
     1,2,3,4,5,6,7,8: solve_WF_matrix.
     1,2: assumption.

--- a/GateHelpers.v
+++ b/GateHelpers.v
@@ -641,8 +641,8 @@ abgate U = ∣0⟩⟨0∣ ⊗ TL .+ ∣0⟩⟨1∣ ⊗ TR .+ ∣1⟩⟨1∣ ⊗ 
 Proof.
 intros U U_unitary zeropassthrough.
 destruct zeropassthrough as [y [WF_y zeropassthrough]].
-destruct (@block_decomp_general 2 U) as [TL [TR [BL [BR [WF_TL [WF_TR [WF_BL [WF_BR decomp]]]]]]]].
-lia. apply U_unitary.
+destruct (@block_decomp 2 U) as [TL [TR [BL [BR [WF_TL [WF_TR [WF_BL [WF_BR decomp]]]]]]]].
+apply U_unitary.
 exists (TL ⊗ I 2), (TR ⊗ I 2), (BR ⊗ I 2).
 split. solve_WF_matrix.
 split. solve_WF_matrix.
@@ -1265,7 +1265,7 @@ assert (WF_BL_block: WF_Matrix ((TR0) † × TL0)). solve_WF_matrix.
 assert (WF_BR_block: WF_Matrix ((TR0) † × TR0 .+ (BR0) † × BR0)). solve_WF_matrix.
 assert (self_eq: (abgate U) † × abgate U = (abgate U) † × abgate U). reflexivity.
 assert (neq40: 4%nat <> 0%nat). lia.
-assert (block_eq:= @block_equalities_general 4%nat ((abgate U) † × abgate U) ((abgate U) † × abgate U) 
+assert (block_eq:= @block_equalities 4%nat ((abgate U) † × abgate U) ((abgate U) † × abgate U) 
 ((TL0) † × TL0) ((TL0) † × TR0) ((TR0) † × TL0) ((TR0) † × TR0 .+ (BR0) † × BR0) (I 4) Zero Zero (I 4) neq40 
 WF_TL0_inv WF_TR_block WF_BL_block WF_BR_block
 (@WF_I 4) (@WF_Zero 4 4) (@WF_Zero 4 4) (@WF_I 4) block_mult abU_inv self_eq).

--- a/Main.v
+++ b/Main.v
@@ -258,13 +258,6 @@ Proof.
   }
 Qed.
 
-Lemma perm_eigenvalues : forall {n} (U D D' : Square n),
-  WF_Unitary U -> WF_Diagonal D -> WF_Diagonal D' -> U × D × U† = D' ->
-  exists (σ : nat -> nat),
-    permutation n σ /\ forall (i : nat), D i i = D' (σ i) (σ i).
-Proof.
-Admitted.
-
 Ltac destruct_disjunctions name :=
   match goal with
   | [ H : _ \/ _ |- _ ] => destruct H as [name | H]; destruct_disjunctions name

--- a/Main.v
+++ b/Main.v
@@ -844,6 +844,104 @@ Proof.
   }
 Qed.
 
+Lemma m3_3 : forall (u0 u1 : C),
+  Cmod u0 = 1 -> Cmod u1 = 1 ->
+    (exists (P : Square 2), WF_Unitary P /\
+      exists (c d : C) (v1 v2 v3 v4 : Vector 4),
+        (* This might not be right since we could have v1 == v2*)
+        Eigenpair (((I 2) ⊗ P) × control (diag2 u0 u1)) (v1, c) /\
+        Eigenpair (((I 2) ⊗ P) × control (diag2 u0 u1)) (v2, c) /\
+        Eigenpair (((I 2) ⊗ P) × control (diag2 u0 u1)) (v3, d) /\
+        Eigenpair (((I 2) ⊗ P) × control (diag2 u0 u1)) (v4, d))
+    <-> u0 = u1 \/ u0 * u1 = C1.
+Proof.
+  intros u0 u1 unit_u0 unit_u1.
+  split.
+  {
+    admit.
+  }
+  {
+    intro.
+    destruct H as [u0_is_u1 | u0u1_is_1].
+    {
+      exists (I 2).
+      split.
+      {
+        apply id_unitary.
+      }
+      {
+        exists C1, u0.
+        rewrite id_kron; Msimpl.
+        {
+          exists ∣0,0⟩, ∣0,1⟩, ∣1,0⟩, ∣1,1⟩.
+          assert (H : control (diag2 u0 u1) = diag4 C1 C1 u0 u1).
+          {
+            lma'.
+            {
+              apply WF_control, WF_diag2.
+            }
+            {
+              apply WF_diag4.
+            }
+            {
+              unfold diag4, diag2, control; simpl.
+              reflexivity.
+            }
+            {
+              unfold diag4, diag2, control; simpl.
+              reflexivity.
+            }
+          }
+          rewrite H, <- u0_is_u1.
+          apply diag4_eigenpairs.
+        }
+        {
+          apply WF_control, WF_diag2.
+        }
+      }
+    }
+    {
+      exists (diag2 C1 u0).
+      split.
+      {
+        admit.
+      }
+      {
+        exists C1, u0.
+        exists ∣1,1⟩, ∣0,0⟩, ∣0,1⟩, ∣1,0⟩.
+        assert (H : I 2 ⊗ diag2 C1 u0 × control (diag2 u0 u1) = diag4 C1 u0 u0 (u0 * u1)).
+        {
+          lma'.
+          {
+            solve_WF_matrix; apply WF_diag2.
+          }
+          {
+            apply WF_diag4.
+          }
+          {
+            unfold diag4, diag2, kron, Mmult; simpl; Csimpl.
+            reflexivity.
+          }
+          {
+            unfold diag4, diag2, kron, Mmult; simpl; Csimpl.
+            reflexivity.
+          }
+          {
+            unfold diag4, diag2, kron, Mmult; simpl; Csimpl.
+            reflexivity.
+          }
+        }
+        rewrite H; clear H.
+        rewrite u0u1_is_1.
+        (* rewrite A /\ B to B /\ A *)
+        rewrite and_comm.
+        repeat rewrite and_assoc.
+        apply diag4_eigenpairs.
+      }
+    }
+  }
+Qed.
+
 Lemma m4_1 : forall (u0 u1 : C),
   Cmod u0 = 1 -> Cmod u1 = 1 ->
     (exists (U V : Square 4) (P0 P1 Q0 Q1: Square 2),

--- a/Main.v
+++ b/Main.v
@@ -529,100 +529,79 @@ Qed.
 Lemma m3_3 : forall (u0 u1 : C),
   Cmod u0 = 1 -> Cmod u1 = 1 ->
     (exists (P : Square 2), WF_Unitary P /\
-      exists (c d : C) (v1 v2 v3 v4 : Vector 4),
-        (* This might not be right since we could have v1 == v2*)
-        Eigenpair (((I 2) ⊗ P) × control (diag2 u0 u1)) (v1, c) /\
-        Eigenpair (((I 2) ⊗ P) × control (diag2 u0 u1)) (v2, c) /\
-        Eigenpair (((I 2) ⊗ P) × control (diag2 u0 u1)) (v3, d) /\
-        Eigenpair (((I 2) ⊗ P) × control (diag2 u0 u1)) (v4, d))
+      exists (U : Square 4), WF_Unitary U /\
+        exists (c d : C),
+          ((I 2) ⊗ P) × control (diag2 u0 u1) = U × diag4 c c d d × U†)
     <-> u0 = u1 \/ u0 * u1 = C1.
 Proof.
   intros u0 u1 unit_u0 unit_u1.
   split.
   {
+    intro.
+    destruct H as [P [Unitary_P [U [Unitary_U [c [d H]]]]]].
     admit.
   }
   {
     intro.
     destruct H as [u0_is_u1 | u0u1_is_1].
     {
+      rewrite <- u0_is_u1.
       exists (I 2).
-      split.
+      split; try apply id_unitary.
+      exists (I 4).
+      split; try apply id_unitary.
+      exists C1, u0.
+      rewrite id_kron; Msimpl; try apply WF_diag4.
       {
-        apply id_unitary.
+        lma'; solve_WF_matrix.
+        apply WF_diag2.
+        apply WF_diag4.
       }
       {
-        exists C1, u0.
-        rewrite id_kron; Msimpl.
-        {
-          exists ∣0,0⟩, ∣0,1⟩, ∣1,0⟩, ∣1,1⟩.
-          assert (H : control (diag2 u0 u1) = diag4 C1 C1 u0 u1).
-          {
-            lma'.
-            {
-              apply WF_control, WF_diag2.
-            }
-            {
-              apply WF_diag4.
-            }
-            {
-              unfold diag4, diag2, control; simpl.
-              reflexivity.
-            }
-            {
-              unfold diag4, diag2, control; simpl.
-              reflexivity.
-            }
-          }
-          rewrite H, <- u0_is_u1.
-          apply diag4_eigenpairs.
-        }
-        {
-          apply WF_control, WF_diag2.
-        }
+        apply WF_control, WF_diag2.
       }
     }
     {
       exists (diag2 C1 u0).
       split.
       {
-        admit.
+        unfold WF_Unitary; split; try apply WF_diag2.
+        lma'; try solve_WF_matrix; try apply WF_diag2.
+        unfold adjoint, diag2, Mmult, I; simpl; Csimpl.
+        rewrite <- Cmod_sqr, unit_u0; lca.
       }
       {
-        exists C1, u0.
-        exists ∣1,1⟩, ∣0,0⟩, ∣0,1⟩, ∣1,0⟩.
-        assert (H : I 2 ⊗ diag2 C1 u0 × control (diag2 u0 u1) = diag4 C1 u0 u0 (u0 * u1)).
+        exists (swap × cnot × swap).
+        split.
         {
-          lma'.
+          repeat apply Mmult_unitary.
+          exact swap_unitary.
+          exact cnot_unitary.
+          exact swap_unitary.
+        }
+        {
+          exists C1, u0.
+          assert (H : I 2 ⊗ diag2 C1 u0 × control (diag2 u0 u1) = diag4 C1 u0 u0 (u0 * u1)).
           {
-            solve_WF_matrix; apply WF_diag2.
+            lma'; solve_WF_matrix; try apply WF_diag2; try apply WF_diag4.
+            all: unfold diag4, diag2, kron, Mmult; simpl; Csimpl; reflexivity.
           }
+          rewrite H; clear H.
+          rewrite u0u1_is_1; clear u0u1_is_1.
+          lma'.
           {
             apply WF_diag4.
           }
           {
-            unfold diag4, diag2, kron, Mmult; simpl; Csimpl.
-            reflexivity.
+            repeat apply WF_mult; try apply WF_swap; try apply WF_cnot; try apply WF_diag4.
+            show_wf.
           }
-          {
-            unfold diag4, diag2, kron, Mmult; simpl; Csimpl.
-            reflexivity.
-          }
-          {
-            unfold diag4, diag2, kron, Mmult; simpl; Csimpl.
-            reflexivity.
-          }
+          all: unfold diag4, swap, cnot, Mmult, adjoint; simpl; Csimpl; reflexivity.
         }
-        rewrite H; clear H.
-        rewrite u0u1_is_1.
-        (* rewrite A /\ B to B /\ A *)
-        rewrite and_comm.
-        repeat rewrite and_assoc.
-        apply diag4_eigenpairs.
       }
     }
   }
-Qed.
+Admitted.
 
 Lemma m4_1 : forall (u0 u1 : C),
   Cmod u0 = 1 -> Cmod u1 = 1 ->

--- a/Main.v
+++ b/Main.v
@@ -39,7 +39,7 @@ Proof.
         U = ∣0⟩⟨0∣ ⊗ V00 .+ ∣0⟩⟨1∣ ⊗ V01 .+ ∣1⟩⟨0∣ ⊗ V10 .+ ∣1⟩⟨1∣ ⊗ V11
       ).
       {
-        apply block_decomp_general; auto.
+        apply block_decomp.
         destruct Unitary_U; assumption.
       }
       destruct block_matrices_U as [V00 [V01 [V10 [V11 block_matrices_U]]]].
@@ -89,7 +89,7 @@ Proof.
           reflexivity.
       }
       rewrite UW, WU in H; clear UW WU W_eq_blocks.
-      apply (@block_equalities_general
+      apply (@block_equalities
         4%nat
         (∣0⟩⟨0∣ ⊗ (u0 .* V00) .+ ∣0⟩⟨1∣ ⊗ (u1 .* V01) .+ ∣1⟩⟨0∣ ⊗ (u0 .* V10) .+ ∣1⟩⟨1∣ ⊗ (u1 .* V11))
         (∣0⟩⟨0∣ ⊗ (u0 .* V00) .+ ∣0⟩⟨1∣ ⊗ (u0 .* V01) .+ ∣1⟩⟨0∣ ⊗ (u1 .* V10) .+ ∣1⟩⟨1∣ ⊗ (u1 .* V11))
@@ -161,7 +161,7 @@ Proof.
         repeat rewrite Mplus_0_l in Unitary_U.
         repeat rewrite Mplus_0_r in Unitary_U.
         apply (
-        @block_equalities_general
+        @block_equalities
         4%nat
         (∣0⟩⟨0∣ ⊗ ((V00) † × V00) .+ ∣0⟩⟨1∣ ⊗ Zero .+ ∣1⟩⟨0∣ ⊗ Zero .+ ∣1⟩⟨1∣ ⊗ ((V11) † × V11))
         (∣0⟩⟨0∣ ⊗ I 4 .+ ∣0⟩⟨1∣ ⊗ Zero .+ ∣1⟩⟨0∣ ⊗ Zero .+ ∣1⟩⟨1∣ ⊗ I 4)

--- a/Main.v
+++ b/Main.v
@@ -1,5 +1,6 @@
 Require Import Proof.UnitaryMatrices.
 Require Import Proof.Permutations.
+Require Import Proof.SquareMatrices.
 Require Import Proof.AlgebraHelpers.
 Require Import Proof.MatrixHelpers.
 Require Import Proof.GateHelpers.
@@ -9,11 +10,8 @@ Require Import QuantumLib.Quantum.
 Require Import QuantumLib.Eigenvectors.
 Require Import QuantumLib.Matrix.
 Require Import QuantumLib.Permutations.
-Require Import Coq.Sets.Ensembles.
-Require Import Coq.Logic.Classical_Pred_Type.
-Require Import Coq.Logic.Classical_Prop.
 
-Lemma m3_1 : forall (u0 u1 : C),
+(* Lemma m3_1 : forall (u0 u1 : C),
   Cmod u0 = 1 -> Cmod u1 = 1 ->
   forall (U : Square 8), WF_Unitary U ->
     (U × ((diag2 u0 u1) ⊗ (I 2) ⊗ (I 2)) = ((diag2 u0 u1) ⊗ (I 2) ⊗ (I 2)) × U <->
@@ -256,13 +254,7 @@ Proof.
       reflexivity.
     }
   }
-Qed.
-
-Ltac destruct_disjunctions name :=
-  match goal with
-  | [ H : _ \/ _ |- _ ] => destruct H as [name | H]; destruct_disjunctions name
-  | _ => idtac
-  end.
+Qed. *)
 
 Lemma m3_2 : forall (u0 u1 : C),
   Cmod u0 = 1 -> Cmod u1 = 1 ->
@@ -478,7 +470,7 @@ Proof.
       }
     }
     {
-      exists (diag2 C1 u0), (diag2 C1 u1), (swap × cnot × swap).
+      exists (diag2 C1 u0), (diag2 C1 u1), notc.
       split.
       {
         unfold WF_Unitary; split; try apply WF_diag2.
@@ -495,24 +487,18 @@ Proof.
       }
       split.
       {
-        repeat apply Mmult_unitary.
-        exact swap_unitary.
-        exact cnot_unitary.
-        exact swap_unitary.
+        exact notc_unitary.
       }
       {
         lma'.
         solve_WF_matrix; try apply WF_diag2.
-        try apply WF_diag4.
-        repeat try apply WF_mult.
-        apply WF_swap.
-        apply WF_cnot.
-        apply WF_swap.
+        repeat apply WF_mult.
+        apply WF_notc.
         apply WF_diag4.
-        apply WF_adjoint, WF_mult, WF_swap; apply WF_mult, WF_cnot; apply WF_swap.
-        unfold diag2, diag4, swap, cnot, Mmult, kron, adjoint; lca.
-        unfold diag2, diag4, swap, cnot, Mmult, kron, adjoint; lca.
-        unfold diag2, diag4, swap, cnot, Mmult, kron, adjoint; simpl; Csimpl.
+        apply WF_adjoint, WF_notc.
+        unfold diag2, diag4; lca.
+        unfold diag2, diag4; lca.
+        unfold notc, Mmult, adjoint; simpl; Csimpl.
         exact u0u1_eq_1.
       }
     }
@@ -523,7 +509,7 @@ Lemma m3_3 : forall (u0 u1 : C),
   Cmod u0 = 1 -> Cmod u1 = 1 ->
     (exists (P : Square 2), WF_Unitary P /\
       exists (U : Square 4), WF_Unitary U /\
-        exists (c d : C),
+        exists (c d : C), c <> C0 /\ d <> C0 /\
           ((I 2) ⊗ P) × control (diag2 u0 u1) = U × diag4 c c d d × U†)
     <-> u0 = u1 \/ u0 * u1 = C1.
 Proof.
@@ -531,8 +517,455 @@ Proof.
   split.
   {
     intro.
-    destruct H as [P [Unitary_P [U [Unitary_U [c [d H]]]]]].
-    admit.
+    destruct H as [P [Unitary_P [U [Unitary_U [c [d [c_neq_0 [d_neq_0 H]]]]]]]].
+    set (PD := P × diag2 u0 u1).
+    assert (Unitary_PD : WF_Unitary (P × diag2 u0 u1)).
+    {
+      apply Mmult_unitary; auto.
+      unfold WF_Unitary; split; try apply WF_diag2.
+      lma'; try solve_WF_matrix; try apply WF_diag2.
+      unfold adjoint, diag2, Mmult, I; simpl; Csimpl.
+      rewrite <- Cmod_sqr, unit_u0; lca.
+      unfold adjoint, diag2, Mmult, I; simpl; Csimpl.
+      rewrite <- Cmod_sqr, unit_u1; lca.
+    }
+    assert (step : control (diag2 u0 u1) = I 2 .⊕ diag2 u0 u1).
+    {
+      rewrite (direct_sum_decomp _ _ 2 2)%nat; auto.
+      lma'.
+      apply WF_control, WF_diag2.
+      solve_WF_matrix; apply WF_diag2.
+      unfold control, diag2, adjoint, I, kron, Mmult, Mplus; simpl; lca.
+      unfold control, diag2, adjoint, I, kron, Mmult, Mplus; simpl; lca.
+      apply WF_I.
+      apply WF_diag2.
+    }
+    assert (step2 : (I 2 ⊗ P) × control (diag2 u0 u1) = P .⊕ PD).
+    {
+      rewrite step.
+      repeat rewrite (direct_sum_decomp _ _ 2 2)%nat; auto.
+      rewrite Mmult_plus_distr_l.
+      repeat rewrite kron_mixed_product; Msimpl_light.
+      reflexivity.
+      apply Unitary_P.
+      apply Unitary_P.
+      apply Unitary_PD.
+      apply WF_I.
+      apply WF_diag2.
+    }
+    pose proof (a3 P Unitary_P) as [VP [DP [Unitary_VP [Diagonal_DP P_decomp]]]].
+    pose proof (a3 PD Unitary_PD) as [VPD [DPD [Unitary_VPD [Diagonal_DPD PD_decomp]]]].
+    assert (step3 : exists σ : nat -> nat,
+      permutation 4 σ /\ (forall i : nat, (DP .⊕ DPD) i i = diag4 c c d d (σ i) (σ i))).
+    {
+      apply (a6 P PD VP DP VPD DPD U); auto.
+      apply Diag_diag4.
+      rewrite H in step2.
+      symmetry; exact step2.
+    }
+    destruct step3 as [σ [permutation_σ step3]].
+
+    all: specialize (step3 0%nat) as eigen0.
+    all: specialize (step3 1%nat) as eigen1.
+    all: specialize (step3 2%nat) as eigen2.
+    all: specialize (step3 3%nat) as eigen3.
+
+    assert (case_A : forall (c d : C), (c <> C0 -> DP 0 0 = c -> DP 1 1 = c ->
+      DPD 0 0 = d -> DPD 1 1 = d -> u0 = u1)%nat).
+    {
+      intros.
+      assert (DP_cI : DP = c0 .* I 2).
+      {
+        lma'.
+        {
+          apply Diagonal_DP.
+        }
+        {
+          unfold scale, I; simpl.
+          rewrite H1; lca.
+        }
+        {
+          unfold scale, I; simpl.
+          destruct Diagonal_DP as [_ DP_0].
+          specialize (DP_0 0 1)%nat.
+          rewrite DP_0; auto.
+          lca.
+        }
+        {
+          unfold scale, I; simpl.
+          destruct Diagonal_DP as [_ DP_0].
+          specialize (DP_0 1 0)%nat.
+          rewrite DP_0; auto.
+          lca.
+        }
+        {
+          unfold scale, I; simpl.
+          rewrite H2; lca.
+        }
+      }
+      assert (DPD_dI : DPD = d0 .* I 2).
+      {
+        lma'.
+        {
+          apply Diagonal_DPD.
+        }
+        {
+          unfold scale, I; simpl.
+          rewrite H3; lca.
+        }
+        {
+          destruct Diagonal_DPD as [_ DPD_0].
+          specialize (DPD_0 0 1)%nat.
+          rewrite DPD_0; auto.
+          lca.
+        }
+        {
+          destruct Diagonal_DPD as [_ DPD_0].
+          specialize (DPD_0 1 0)%nat.
+          rewrite DPD_0; auto.
+          lca.
+        }
+        {
+          unfold scale, I; simpl.
+          rewrite H4; lca.
+        }
+      }
+      rewrite DP_cI in P_decomp; clear DP_cI.
+      rewrite DPD_dI in PD_decomp; clear DPD_dI.
+      clear H1 H2.
+      assert (diag2_decomp : forall (x : C), diag2 x x = x .* I 2).
+      {
+        intros.
+        lma'.
+        apply WF_diag2.
+        unfold diag2; lca.
+        unfold diag2; lca.
+      }
+      assert (P_cI : P = c0 .* I 2).
+      {
+        rewrite P_decomp.
+        rewrite Mscale_mult_dist_r.
+        rewrite Mmult_1_r; try apply Unitary_VP.
+        rewrite Mscale_mult_dist_l.
+        rewrite other_unitary_decomp; auto.
+      }
+      assert (PD_dI : PD = d0 .* I 2).
+      {
+        rewrite PD_decomp.
+        rewrite Mscale_mult_dist_r.
+        rewrite Mmult_1_r; try apply Unitary_VPD.
+        rewrite Mscale_mult_dist_l.
+        rewrite other_unitary_decomp; auto.
+      }
+      unfold PD in PD_dI.
+      rewrite P_cI in PD_dI; clear P_cI.
+      rewrite Mscale_mult_dist_l in PD_dI.
+      rewrite Mmult_1_l in PD_dI; try apply WF_diag2.
+      assert (cu0_d : c0 * u0 = d0).
+      {
+        apply (f_equal (fun f => f 0 0)%nat) in PD_dI.
+        unfold scale, diag2, I in PD_dI; simpl in PD_dI.
+        rewrite PD_dI; lca.
+      }
+      assert (cu1_d : c0 * u1 = d0).
+      {
+        apply (f_equal (fun f => f 1 1)%nat) in PD_dI.
+        unfold scale, diag2, I in PD_dI; simpl in PD_dI.
+        rewrite PD_dI; lca.
+      }
+      apply (Cmult_cancel_l c0); try apply H0.
+      rewrite cu0_d, cu1_d; reflexivity.
+    }
+    assert (case_B : forall (c d : C), c <> C0 -> d <> C0 ->
+      (DP 0 0)%nat = c -> (DP 1 1)%nat = d ->
+      (DPD 0 0)%nat = c -> (DPD 1 1)%nat = d -> u0 * u1 = C1).
+    {
+      intros.
+      assert (DP_diag : DP = diag2 c0 d0).
+      {
+        lma'.
+        {
+          apply Diagonal_DP.
+        }
+        {
+          apply WF_diag2.
+        }
+        {
+          unfold diag2; simpl.
+          rewrite H2; reflexivity.
+        }
+        {
+          destruct Diagonal_DP as [_ DP_0].
+          specialize (DP_0 0 1)%nat.
+          rewrite DP_0; auto.
+        }
+        {
+          destruct Diagonal_DP as [_ DP_0].
+          specialize (DP_0 1 0)%nat.
+          rewrite DP_0; auto.
+        }
+        {
+          unfold diag2; simpl.
+          rewrite H3; reflexivity.
+        }
+      }
+      assert (DPD_diag : DPD = diag2 c0 d0).
+      {
+        lma'.
+        {
+          apply Diagonal_DPD.
+        }
+        {
+          apply WF_diag2.
+        }
+        {
+          unfold diag2; simpl.
+          rewrite H4; reflexivity.
+        }
+        {
+          destruct Diagonal_DPD as [_ DPD_0].
+          specialize (DPD_0 0 1)%nat.
+          rewrite DPD_0; auto.
+        }
+        {
+          destruct Diagonal_DPD as [_ DPD_0].
+          specialize (DPD_0 1 0)%nat.
+          rewrite DPD_0; auto.
+        }
+        {
+          unfold diag2; simpl.
+          rewrite H5; reflexivity.
+        }
+      }
+      rewrite DP_diag in P_decomp; clear DP_diag.
+      rewrite DPD_diag in PD_decomp; clear DPD_diag.
+      assert (detP : Determinant P = c0 * d0).
+      {
+        rewrite P_decomp.
+        repeat rewrite a1.
+        rewrite Cmult_comm, Cmult_assoc.
+        rewrite <- a1.
+        destruct Unitary_VP as [_ Unitary_VP].
+        rewrite Unitary_VP.
+        rewrite Det_I, Cmult_1_l.
+        apply Det_diag2.
+      }
+      assert (detPD : Determinant PD = c0 * d0).
+      {
+        rewrite PD_decomp.
+        repeat rewrite a1.
+        rewrite Cmult_comm, Cmult_assoc.
+        rewrite <- a1.
+        destruct Unitary_VPD as [_ Unitary_VPD].
+        rewrite Unitary_VPD.
+        rewrite Det_I, Cmult_1_l.
+        rewrite Det_diag2; reflexivity.
+      }
+      unfold PD in detPD.
+      rewrite a1 in detPD.
+      rewrite detP, Det_diag2 in detPD.
+      apply (Cmult_cancel_l (c0 * d0)).
+      apply Cmult_nonzero; auto.
+      rewrite detPD; lca.
+    }
+    assert (case_C : forall (c d : C), c <> C0 -> d <> C0 ->
+      (DP 0 0)%nat = c -> (DP 1 1)%nat = d ->
+      (DPD 0 0)%nat = d -> (DPD 1 1)%nat = c -> u0 * u1 = C1).
+    {
+      intros.
+      assert (DP_diag : DP = diag2 c0 d0).
+      {
+        lma'.
+        {
+          apply Diagonal_DP.
+        }
+        {
+          apply WF_diag2.
+        }
+        {
+          unfold diag2; simpl.
+          rewrite H2; reflexivity.
+        }
+        {
+          destruct Diagonal_DP as [_ DP_0].
+          specialize (DP_0 0 1)%nat.
+          rewrite DP_0; auto.
+        }
+        {
+          destruct Diagonal_DP as [_ DP_0].
+          specialize (DP_0 1 0)%nat.
+          rewrite DP_0; auto.
+        }
+        {
+          unfold diag2; simpl.
+          rewrite H3; reflexivity.
+        }
+      }
+      assert (DPD_diag : DPD = diag2 d0 c0).
+      {
+        lma'.
+        {
+          apply Diagonal_DPD.
+        }
+        {
+          apply WF_diag2.
+        }
+        {
+          unfold diag2; simpl.
+          rewrite H4; reflexivity.
+        }
+        {
+          destruct Diagonal_DPD as [_ DPD_0].
+          specialize (DPD_0 0 1)%nat.
+          rewrite DPD_0; auto.
+        }
+        {
+          destruct Diagonal_DPD as [_ DPD_0].
+          specialize (DPD_0 1 0)%nat.
+          rewrite DPD_0; auto.
+        }
+        {
+          unfold diag2; simpl.
+          rewrite H5; reflexivity.
+        }
+      }
+      rewrite DP_diag in P_decomp; clear DP_diag.
+      rewrite DPD_diag in PD_decomp; clear DPD_diag.
+      unfold PD in PD_decomp.
+      assert (detP : Determinant P = c0 * d0).
+      {
+        rewrite P_decomp.
+        repeat rewrite a1.
+        rewrite Cmult_comm, Cmult_assoc.
+        rewrite <- a1.
+        destruct Unitary_VP as [_ Unitary_VP].
+        rewrite Unitary_VP.
+        rewrite Det_I, Cmult_1_l.
+        apply Det_diag2.
+      }
+      assert (detPD : Determinant PD = c0 * d0).
+      {
+        unfold PD.
+        rewrite PD_decomp.
+        repeat rewrite a1.
+        rewrite Cmult_comm, Cmult_assoc.
+        rewrite <- a1.
+        destruct Unitary_VPD as [_ Unitary_VPD].
+        rewrite Unitary_VPD.
+        rewrite Det_I, Cmult_1_l.
+        rewrite Det_diag2, Cmult_comm; reflexivity.
+      }
+      unfold PD in detPD.
+      rewrite a1 in detPD.
+      rewrite detP, Det_diag2 in detPD.
+      apply (Cmult_cancel_l (c0 * d0)).
+      apply Cmult_nonzero; auto.
+      rewrite detPD; lca.
+    }
+
+    pose proof (permutation_4_decomp σ permutation_σ) as perm.
+    destruct_disjunctions perm.
+    all: destruct perm as [σ0 [σ1 [σ2 σ3]]].
+    all: unfold direct_sum, diag4 in eigen0; rewrite σ0 in eigen0; simpl in eigen0; clear σ0.
+    all: unfold direct_sum, diag4 in eigen1; rewrite σ1 in eigen1; simpl in eigen1; clear σ1.
+    all: unfold direct_sum, diag4 in eigen2; rewrite σ2 in eigen2; simpl in eigen2; clear σ2.
+    all: unfold direct_sum, diag4 in eigen3; rewrite σ3 in eigen3; simpl in eigen3; clear σ3.
+    {
+      left.
+      apply (case_A c d); auto.
+    }
+    {
+      left.
+      apply (case_A c d); auto.
+    }
+    {
+      right.
+      apply (case_B c d); auto.
+    }
+    {
+      right.
+      apply (case_C c d); auto.
+    }
+    {
+      right.
+      apply (case_B c d); auto.
+    }
+    {
+      right.
+      apply (case_C c d); auto.
+    }
+    {
+      left.
+      apply (case_A c d); auto.
+    }
+    {
+      left.
+      apply (case_A c d); auto.
+    }
+    {
+      right.
+      apply (case_B c d); auto.
+    }
+    {
+      right.
+      apply (case_C c d); auto.
+    }
+    {
+      right.
+      apply (case_B c d); auto.
+    }
+    {
+      right.
+      apply (case_C c d); auto.
+    }
+    {
+      right.
+      apply (case_C d c); auto.
+    }
+    {
+      right.
+      apply (case_B d c); auto.
+    }
+    {
+      right.
+      apply (case_C d c); auto.
+    }
+    {
+      right.
+      apply (case_B d c); auto.
+    }
+    {
+      left.
+      apply (case_A d c); auto.
+    }
+    {
+      left.
+      apply (case_A d c); auto.
+    }
+    {
+      right.
+      apply (case_C d c); auto.
+    }
+    {
+      right.
+      apply (case_B d c); auto.
+    }
+    {
+      right.
+      apply (case_C d c); auto.
+    }
+    {
+      right.
+      apply (case_B d c); auto.
+    }
+    {
+      left.
+      apply (case_A d c); auto.
+    }
+    {
+      left.
+      apply (case_A d c); auto.
+    }
   }
   {
     intro.
@@ -544,6 +977,8 @@ Proof.
       exists (I 4).
       split; try apply id_unitary.
       exists C1, u0.
+      split; try apply C1_neq_C0.
+      split. rewrite Cmod_gt_0, unit_u0; lra.
       rewrite id_kron; Msimpl; try apply WF_diag4.
       {
         lma'; solve_WF_matrix.
@@ -564,16 +999,15 @@ Proof.
         rewrite <- Cmod_sqr, unit_u0; lca.
       }
       {
-        exists (swap × cnot × swap).
+        exists notc.
         split.
         {
-          repeat apply Mmult_unitary.
-          exact swap_unitary.
-          exact cnot_unitary.
-          exact swap_unitary.
+          exact notc_unitary.
         }
         {
           exists C1, u0.
+          split; try apply C1_neq_C0.
+          split; try rewrite Cmod_gt_0, unit_u0; try lra.
           assert (H : I 2 ⊗ diag2 C1 u0 × control (diag2 u0 u1) = diag4 C1 u0 u0 (u0 * u1)).
           {
             lma'; solve_WF_matrix; try apply WF_diag2; try apply WF_diag4.
@@ -586,15 +1020,17 @@ Proof.
             apply WF_diag4.
           }
           {
-            repeat apply WF_mult; try apply WF_swap; try apply WF_cnot; try apply WF_diag4.
-            show_wf.
+            repeat apply WF_mult.
+            apply WF_notc.
+            apply WF_diag4.
+            apply WF_adjoint, WF_notc.
           }
           all: unfold diag4, swap, cnot, Mmult, adjoint; simpl; Csimpl; reflexivity.
         }
       }
     }
   }
-Admitted.
+Qed.
 
 Lemma m4_1 : forall (u0 u1 : C),
   Cmod u0 = 1 -> Cmod u1 = 1 ->

--- a/MatrixHelpers.v
+++ b/MatrixHelpers.v
@@ -144,6 +144,12 @@ Proof.
   }
 Qed.
 
+Lemma Det_diag2 : forall (c1 c2 : C), Determinant (diag2 c1 c2) = c1 * c2.
+Proof.
+  intros.
+  unfold diag2, Determinant, big_sum, parity, get_minor; lca.
+Qed.
+
 Lemma Diag_diag4: forall (c1 c2 c3 c4 : C), WF_Diagonal (diag4 c1 c2 c3 c4).
 Proof.
   intros.

--- a/MatrixHelpers.v
+++ b/MatrixHelpers.v
@@ -678,7 +678,7 @@ intros.
 lca.
 Qed.
 
-Lemma block_equalities_general {n}: forall (U V: Square (n+n)) (P00 P01 P10 P11 Q00 Q01 Q10 Q11: Square n),
+Lemma block_equalities {n}: forall (U V: Square (n+n)) (P00 P01 P10 P11 Q00 Q01 Q10 Q11: Square n),
 n <> 0%nat ->  
 WF_Matrix P00 -> WF_Matrix P01 -> WF_Matrix P10 -> WF_Matrix P11 ->
 WF_Matrix Q00 -> WF_Matrix Q01 -> WF_Matrix Q10 -> WF_Matrix Q11 ->
@@ -1213,12 +1213,25 @@ rewrite <- Cconj_0.
 apply Cconj_simplify. do 2 rewrite Cconj_involutive. assumption.
 Qed.
 
-Lemma block_decomp_general {n}: forall (U: Square (2*n)), n <> 0%nat -> WF_Matrix U -> 
+Lemma block_decomp {n}: forall (U: Square (2*n)), WF_Matrix U ->
 exists (TL TR BL BR : Square n), 
 WF_Matrix TL /\ WF_Matrix TR /\ WF_Matrix BL /\ WF_Matrix BR /\
 U = ∣0⟩⟨0∣ ⊗ TL .+ ∣0⟩⟨1∣ ⊗ TR .+ ∣1⟩⟨0∣ ⊗ BL .+ ∣1⟩⟨1∣ ⊗ BR.
 Proof.
-intros U nn0 WF_U.
+intros U WF_U.
+destruct (Nat.eq_dec n 0%nat) as [n0 | nn0].
+{
+  exists Zero, Zero, Zero, Zero.
+  split. apply WF_Zero.
+  split. apply WF_Zero.
+  split. apply WF_Zero.
+  split. apply WF_Zero.
+  Msimpl.
+  apply WF0_Zero.
+  unfold WF_Matrix in WF_U.
+  rewrite n0 in WF_U.
+  assumption.
+}
 set (TL := (fun x y => if (x <? n) && (y <? n) then U x y else 0 ): Square n).
 assert (WF_TL: WF_Matrix TL).
 {

--- a/OtherProperties.v
+++ b/OtherProperties.v
@@ -158,8 +158,7 @@ do 2 rewrite Mplus_0_r in V3_way1.
 do 2 rewrite Mplus_assoc in V3_way1. rewrite Mplus_comm with (A:= ∣1⟩⟨1∣
 ⊗ ((V2) † × (I 2 ⊗ (P1) †) × U1 × (V4) †)) in V3_way1.
 repeat rewrite <- Mplus_assoc in V3_way1.
-assert (ne20: 2%nat <> 0%nat). lia.
-assert (v3_decomp:= @block_decomp_general 2 V3 ne20 WF_v3).
+assert (v3_decomp:= @block_decomp 2 V3 WF_v3).
 destruct v3_decomp as [Q00 [Q01 [Q10 [Q11 [WF_Q00 [WF_Q01 [WF_Q10 [WF_Q11 v3_decomp]]]]]]]].
 assert (V3_way2: acgate V3 = swapbc × abgate V3 × swapbc). unfold acgate. reflexivity.
 unfold abgate in V3_way2.
@@ -175,7 +174,7 @@ rewrite kron_assoc in V3_way2. 2,3,4: solve_WF_matrix.
 rewrite kron_assoc in V3_way2. 2,3,4: solve_WF_matrix.
 rewrite kron_assoc in V3_way2. 2,3,4: solve_WF_matrix.
 rewrite kron_assoc in V3_way2. 2,3,4: solve_WF_matrix.
-assert (block_eq := @block_equalities_general 4 (acgate V3) (acgate V3)
+assert (block_eq := @block_equalities 4 (acgate V3) (acgate V3)
 ((V2) † × (I 2 ⊗ (P0) †) × U0 × (V4) †) (@Zero 4 4) (@Zero 4 4) ((V2) † × (I 2 ⊗ (P1) †) × U1 × (V4) †)
 (I 2 ⊗ Q00) (I 2 ⊗ Q01) (I 2 ⊗ Q10) (I 2 ⊗ Q11)).
 assert (eq: (V2) † × (I 2 ⊗ (P0) †) × U0 × (V4) † = I 2 ⊗ Q00 /\
@@ -226,7 +225,7 @@ repeat rewrite Mmult_0_r in block_unit.
 repeat rewrite Mmult_0_l in block_unit.
 repeat rewrite Mplus_0_r in block_unit.
 repeat rewrite Mplus_0_l in block_unit.
-assert (block_eq_2 := @block_equalities_general 2 (∣0⟩⟨0∣ ⊗ ((Q00) † × Q00) .+ ∣0⟩⟨1∣ ⊗ Zero .+ ∣1⟩⟨0∣ ⊗ Zero
+assert (block_eq_2 := @block_equalities 2 (∣0⟩⟨0∣ ⊗ ((Q00) † × Q00) .+ ∣0⟩⟨1∣ ⊗ Zero .+ ∣1⟩⟨0∣ ⊗ Zero
 .+ ∣1⟩⟨1∣ ⊗ ((Q11) † × Q11)) (∣0⟩⟨0∣ ⊗ I 2 .+ ∣0⟩⟨1∣ ⊗ Zero .+ ∣1⟩⟨0∣ ⊗ Zero .+ ∣1⟩⟨1∣ ⊗ I 2)
 ((Q00) † × Q00) (Zero) (Zero) ((Q11) † × Q11) (I 2) (Zero) (Zero) (I 2)).
 assert (unit_eq: (Q00) † × Q00 = I 2 /\

--- a/Permutations.v
+++ b/Permutations.v
@@ -1,0 +1,257 @@
+Require Import Lia.
+Require Import QuantumLib.Permutations.
+Require Import Coq.Sets.Ensembles.
+Require Import Coq.Logic.Classical_Pred_Type.
+Require Import Coq.Logic.Classical_Prop.
+
+(* To equate the eigenvalues of two matrices, we often need equality of matrices
+   up to some permutation. This lemma allows us to take the existence of a
+   permutation on 4 elements and decompose it into the 24 possible cases. *)
+Lemma permutation_4_decomp : forall (σ : nat -> nat),
+  permutation 4 σ -> (
+    (σ 0 = 0 /\ σ 1 = 1 /\ σ 2 = 2 /\ σ 3 = 3) \/
+    (σ 0 = 0 /\ σ 1 = 1 /\ σ 2 = 3 /\ σ 3 = 2) \/
+    (σ 0 = 0 /\ σ 1 = 2 /\ σ 2 = 1 /\ σ 3 = 3) \/
+    (σ 0 = 0 /\ σ 1 = 2 /\ σ 2 = 3 /\ σ 3 = 1) \/
+    (σ 0 = 0 /\ σ 1 = 3 /\ σ 2 = 1 /\ σ 3 = 2) \/
+    (σ 0 = 0 /\ σ 1 = 3 /\ σ 2 = 2 /\ σ 3 = 1) \/
+    (σ 0 = 1 /\ σ 1 = 0 /\ σ 2 = 2 /\ σ 3 = 3) \/
+    (σ 0 = 1 /\ σ 1 = 0 /\ σ 2 = 3 /\ σ 3 = 2) \/
+    (σ 0 = 1 /\ σ 1 = 2 /\ σ 2 = 0 /\ σ 3 = 3) \/
+    (σ 0 = 1 /\ σ 1 = 2 /\ σ 2 = 3 /\ σ 3 = 0) \/
+    (σ 0 = 1 /\ σ 1 = 3 /\ σ 2 = 0 /\ σ 3 = 2) \/
+    (σ 0 = 1 /\ σ 1 = 3 /\ σ 2 = 2 /\ σ 3 = 0) \/
+    (σ 0 = 2 /\ σ 1 = 0 /\ σ 2 = 1 /\ σ 3 = 3) \/
+    (σ 0 = 2 /\ σ 1 = 0 /\ σ 2 = 3 /\ σ 3 = 1) \/
+    (σ 0 = 2 /\ σ 1 = 1 /\ σ 2 = 0 /\ σ 3 = 3) \/
+    (σ 0 = 2 /\ σ 1 = 1 /\ σ 2 = 3 /\ σ 3 = 0) \/
+    (σ 0 = 2 /\ σ 1 = 3 /\ σ 2 = 0 /\ σ 3 = 1) \/
+    (σ 0 = 2 /\ σ 1 = 3 /\ σ 2 = 1 /\ σ 3 = 0) \/
+    (σ 0 = 3 /\ σ 1 = 0 /\ σ 2 = 1 /\ σ 3 = 2) \/
+    (σ 0 = 3 /\ σ 1 = 0 /\ σ 2 = 2 /\ σ 3 = 1) \/
+    (σ 0 = 3 /\ σ 1 = 1 /\ σ 2 = 0 /\ σ 3 = 2) \/
+    (σ 0 = 3 /\ σ 1 = 1 /\ σ 2 = 2 /\ σ 3 = 0) \/
+    (σ 0 = 3 /\ σ 1 = 2 /\ σ 2 = 0 /\ σ 3 = 1) \/
+    (σ 0 = 3 /\ σ 1 = 2 /\ σ 2 = 1 /\ σ 3 = 0)
+  )%nat.
+Proof.
+  assert (perm_values : forall {n} (σ : nat -> nat),
+    permutation n σ ->
+      let N : Ensemble nat := (fun x => x < n)%nat in
+      forall (i : nat),
+        (i < n)%nat ->
+          let Image := (fun x => exists (j : nat), (j < i)%nat /\ σ j = x) in
+          In nat (Setminus nat N Image) (σ i)).
+  {
+    intros n σ permutation_σ N i i_lt_n Image.
+    unfold Setminus, In, N, Image.
+    split.
+    {
+      destruct permutation_σ as [σ_inv H].
+      apply H.
+      assumption.
+    }
+    {
+      apply all_not_not_ex.
+      intros m [m_lt_i σm_eq_σi].
+      assert (m_lt_n : (m < n)%nat) by lia.
+      pose proof (
+        permutation_is_injective n σ permutation_σ m i m_lt_n i_lt_n σm_eq_σi
+      ) as m_eq_i.
+      lia.
+    }
+  }
+  intros σ permutation_σ.
+  pose proof (perm_values 4%nat σ permutation_σ) as perm_helper.
+
+  specialize (perm_helper 0%nat) as perm_helper_0.
+  destruct perm_helper_0 as [σ0_lt_4 _]; auto; unfold In in σ0_lt_4.
+
+  specialize (perm_helper 1%nat) as perm_helper_1.
+  destruct perm_helper_1 as [σ1_lt_4 help0]; auto; unfold In in σ1_lt_4.
+  unfold In in help0.
+  pose proof (not_ex_all_not _ _ help0) as helper0; clear help0.
+  specialize (helper0 0%nat) as σ0_neq_σ1; clear helper0.
+  revert σ0_neq_σ1; simpl; intro σ0_neq_σ1.
+  apply not_and_or in σ0_neq_σ1.
+  destruct σ0_neq_σ1 as [absurd | σ0_neq_σ1]. lia.
+
+  specialize (perm_helper 2%nat) as perm_helper_2.
+  destruct perm_helper_2 as [σ2_lt_4 help1]; auto; unfold In in σ2_lt_4.
+  unfold In in help1.
+  pose proof (not_ex_all_not _ _ help1) as helper1; clear help1.
+  specialize (helper1 0%nat) as σ0_neq_σ2.
+  specialize (helper1 1%nat) as σ1_neq_σ2; clear helper1.
+  revert σ0_neq_σ2 σ1_neq_σ2. simpl. intros σ0_neq_σ2 σ1_neq_σ2.
+  apply not_and_or in σ0_neq_σ2, σ1_neq_σ2.
+  destruct σ0_neq_σ2 as [absurd | σ0_neq_σ2]. lia.
+  destruct σ1_neq_σ2 as [absurd | σ1_neq_σ2]. lia.
+
+  specialize (perm_helper 3%nat) as perm_helper_3.
+  destruct perm_helper_3 as [σ3_lt_4 help2]; auto; unfold In in σ3_lt_4.
+  unfold In in help2.
+  pose proof (not_ex_all_not _ _ help2) as helper2; clear help2.
+  specialize (helper2 0%nat) as σ0_neq_σ3.
+  specialize (helper2 1%nat) as σ1_neq_σ3.
+  specialize (helper2 2%nat) as σ2_neq_σ3; clear helper2.
+  revert σ0_neq_σ3 σ1_neq_σ3 σ2_neq_σ3. simpl. intros σ0_neq_σ3 σ1_neq_σ3 σ2_neq_σ3.
+  apply not_and_or in σ0_neq_σ3, σ1_neq_σ3, σ2_neq_σ3.
+  destruct σ0_neq_σ3 as [absurd | σ0_neq_σ3]. lia.
+  destruct σ1_neq_σ3 as [absurd | σ1_neq_σ3]. lia.
+  destruct σ2_neq_σ3 as [absurd | σ2_neq_σ3]. lia.
+  destruct (σ 0%nat).
+  {
+    destruct (σ 1%nat); try contradiction.
+    destruct n.
+    {
+      destruct (σ 2%nat); try contradiction.
+      destruct n; try contradiction.
+      destruct n.
+      {
+        destruct (σ 3%nat); try contradiction.
+        destruct n; try contradiction.
+        destruct n; try contradiction.
+        destruct n; try lia.
+      }
+      {
+        destruct n; try lia.
+      }
+    }
+    {
+      destruct n.
+      {
+        destruct (σ 2%nat); try contradiction.
+        destruct n.
+        {
+          destruct (σ 3%nat); try contradiction.
+          destruct n; try contradiction.
+          destruct n; try contradiction.
+          destruct n; try lia.
+        }
+        {
+          destruct n; try contradiction.
+          destruct n; try lia.
+        }
+      }
+      {
+        destruct n; try lia.
+      }
+    }
+  }
+  {
+    destruct n.
+    {
+      destruct (σ 1%nat).
+      {
+        destruct (σ 2%nat); try contradiction.
+        destruct n; try contradiction.
+        destruct n.
+        {
+          destruct (σ 3%nat); try contradiction.
+          destruct n; try contradiction.
+          destruct n; try contradiction.
+          destruct n; try lia.
+        }
+        {
+          destruct n; try lia.
+        }
+      }
+      {
+        destruct n; try contradiction.
+        destruct n.
+        {
+          destruct (σ 2%nat); try contradiction.
+          {
+            destruct (σ 3%nat); try contradiction.
+            destruct n; try contradiction.
+            destruct n; try contradiction.
+            destruct n; try lia.
+          }
+          {
+            destruct n; try contradiction.
+            destruct n; try contradiction.
+            destruct n; try lia.
+          }
+        }
+        {
+          destruct n; try lia.
+        }
+      }
+    }
+    {
+      destruct n.
+      {
+        destruct (σ 1%nat).
+        {
+          destruct (σ 2%nat); try contradiction.
+          destruct n.
+          {
+            destruct (σ 3%nat); try contradiction.
+            destruct n; try contradiction.
+            destruct n; try contradiction.
+            destruct n; try lia.
+          }
+          {
+            destruct n; try contradiction.
+            destruct n; try lia.
+          }
+        }
+        {
+          destruct n.
+          {
+            destruct (σ 2%nat).
+            {
+              destruct (σ 3%nat); try contradiction.
+              destruct n; try contradiction.
+              destruct n; try contradiction.
+              destruct n; try lia.
+            }
+            {
+              destruct n; try contradiction.
+              destruct n; try contradiction.
+              destruct n; try lia.
+            }
+          }
+          {
+            destruct n; try contradiction.
+            destruct n; try lia.
+          }
+        }
+      }
+      {
+        destruct n. 2: { exfalso. lia. }
+        destruct (σ 1%nat).
+        {
+          destruct (σ 2%nat); try contradiction.
+          destruct n.
+          {
+            destruct (σ 3%nat); try contradiction.
+            destruct n; try contradiction.
+            destruct n; try lia.
+          }
+          {
+            destruct n; try lia.
+          }
+        }
+        {
+          destruct n.
+          {
+            destruct (σ 2%nat).
+            {
+              destruct (σ 3%nat); try contradiction.
+              destruct n; try contradiction.
+              destruct n; try lia.
+            }
+            {
+              destruct n; try contradiction.
+              destruct n; try lia.
+            }
+          }
+          {
+            destruct n; try lia.
+          }
+        }
+      }
+    }
+  }
+Qed.

--- a/Permutations.v
+++ b/Permutations.v
@@ -1,8 +1,18 @@
 Require Import Lia.
 Require Import QuantumLib.Permutations.
+Require Import QuantumLib.Matrix.
+Require Import QuantumLib.Quantum.
+Require Import QuantumLib.Eigenvectors.
 Require Import Coq.Sets.Ensembles.
 Require Import Coq.Logic.Classical_Pred_Type.
 Require Import Coq.Logic.Classical_Prop.
+
+Lemma perm_eigenvalues : forall {n} (U D D' : Square n),
+  WF_Unitary U -> WF_Diagonal D -> WF_Diagonal D' -> U × D × U† = D' ->
+  exists (σ : nat -> nat),
+    permutation n σ /\ forall (i : nat), D i i = D' (σ i) (σ i).
+Proof.
+Admitted.
 
 (* To equate the eigenvalues of two matrices, we often need equality of matrices
    up to some permutation. This lemma allows us to take the existence of a

--- a/Permutations.v
+++ b/Permutations.v
@@ -265,3 +265,10 @@ Proof.
     }
   }
 Qed.
+
+(* Helper tactic to quickly destruct cases and assign them a uniform name *)
+Ltac destruct_disjunctions name :=
+  match goal with
+  | [ H : _ \/ _ |- _ ] => destruct H as [name | H]; destruct_disjunctions name
+  | _ => idtac
+  end.

--- a/UnitaryMatrices.v
+++ b/UnitaryMatrices.v
@@ -449,7 +449,7 @@ assert (block_decomp: ∣0⟩⟨0∣ ⊗ (P00 × P00†) .+ ∣0⟩⟨1∣ ⊗ (
 clear V_unitary Vadj_unitary lr_mult rl_mult.
 assert (P00_decomp: P00 × P00† = P00† × P00 .+ P10† × P10).
 {
-    apply block_equalities_general with (P00:= P00 × (P00) †) (P01 := P00 × (P10) †) (P10:= P10 × (P00) †) (P11 := P10 × (P10) † .+ P11 × (P11) †)
+    apply block_equalities with (P00:= P00 × (P00) †) (P01 := P00 × (P10) †) (P10:= P10 × (P00) †) (P11 := P10 × (P10) † .+ P11 × (P11) †)
     (Q00:= (P00) † × P00 .+ (P10) † × P10) (Q01 := (P10) † × P11) (Q10:= (P11) † × P10) (Q11 := (P11) † × P11) in block_decomp.
     2: lia.
     2,3,4,5,6,7,8,9,10,11: solve_WF_matrix.

--- a/UnitaryMatrices.v
+++ b/UnitaryMatrices.v
@@ -160,105 +160,35 @@ Lemma direct_sum_diagonal : forall {n : nat} (P Q : Square n),
   WF_Diagonal P -> WF_Diagonal Q -> WF_Diagonal (P .⊕ Q).
 Proof.
   intros n P Q [WF_P Diagonal_P] [WF_Q Diagonal_Q].
-  rewrite direct_sum_decomp; auto.
   split.
   {
-    replace (n + n)%nat with (2 * n)%nat by lia.
-    solve_WF_matrix.
+    apply WF_direct_sum; try lia; assumption.
   }
   {
-    assert (WF_sum : WF_Matrix (∣0⟩⟨0∣ ⊗ P .+ ∣1⟩⟨1∣ ⊗ Q)) by solve_WF_matrix.
-    destruct n.
+    intros i j i_neq_j.
+    specialize (Diagonal_P i j i_neq_j).
+    specialize (Diagonal_Q (i - n) (j - n))%nat.
+    unfold direct_sum.
+    destruct (i <? n) eqn:L1.
     {
-      intros.
-      unfold kron, Mplus; simpl.
-      rewrite WF_P, WF_Q; try lia.
-      lca.
+      simpl; exact Diagonal_P.
     }
     {
-      unfold WF_Matrix in WF_sum.
-      intros.
-      destruct (i <? 2 * (S n)) eqn:L1.
+      destruct (j <? n) eqn:L2.
       {
-        apply Nat.ltb_lt in L1.
-        destruct (j <? 2 * (S n)) eqn:L2.
-        {
-          apply Nat.ltb_lt in L2.
-          unfold kron, Mplus.
-          destruct (i <? (S n)) eqn:L3.
-          {
-            apply Nat.ltb_lt in L3.
-            destruct (j <? (S n)) eqn:L4.
-            {
-              apply Nat.ltb_lt in L4.
-              repeat rewrite Nat.mod_small; auto.
-              specialize (Diagonal_P i j).
-              specialize (Diagonal_Q i j).
-              rewrite Diagonal_P, Diagonal_Q; auto; lca.
-            }
-            {
-              apply Nat.ltb_ge in L4.
-              assert (step : (i / (S n) < 1)%nat).
-              {
-                apply Nat.Div0.div_lt_upper_bound; lia.
-              }
-              replace (i / (S n))%nat with 0%nat by lia; clear step.
-              assert (step1 : (j / (S n) < 2)%nat).
-              {
-                apply Nat.Div0.div_lt_upper_bound; lia.
-              }
-              assert (step2 : (j / (S n) >= 1)%nat).
-              {
-                rewrite <- (Nat.div_same (S n)); try lia.
-                apply Nat.Div0.div_le_mono; auto.
-              }
-              replace (j / (S n))%nat with 1%nat by lia; clear step1 step2.
-              lca.
-            }
-          }
-          {
-            apply Nat.ltb_ge in L3.
-            destruct (j <? (S n)) eqn:L4.
-            {
-              apply Nat.ltb_lt in L4.
-              assert (step : (j / (S n) < 1)%nat).
-              {
-                apply Nat.Div0.div_lt_upper_bound; lia.
-              }
-              replace (j / (S n))%nat with 0%nat by lia; clear step.
-              assert (step1 : (i / (S n) < 2)%nat).
-              {
-                apply Nat.Div0.div_lt_upper_bound; lia.
-              }
-              assert (step2 : (i / (S n) >= 1)%nat).
-              {
-                rewrite <- (Nat.div_same (S n)); try lia.
-                apply Nat.Div0.div_le_mono; auto.
-              }
-              replace (i / (S n))%nat with 1%nat by lia; clear step1 step2.
-              lca.
-            }
-            {
-              apply Nat.ltb_ge in L4.
-              assert (H0 : i mod (S n) <> j mod (S n)) by admit.
-              specialize (Diagonal_P (i mod (S n)) (j mod (S n)) H0).
-              specialize (Diagonal_Q (i mod (S n)) (j mod (S n)) H0).
-              rewrite Diagonal_P, Diagonal_Q; lca.
-            }
-          }
-        }
-        {
-          apply Nat.ltb_ge in L2.
-          apply WF_sum; auto.
-        }
+        simpl; exact Diagonal_P.
       }
       {
-        apply Nat.ltb_ge in L1.
-        apply WF_sum; auto.
+        apply Nat.ltb_ge in L1, L2.
+        simpl; apply Diagonal_Q.
+        intro in_eq_jn.
+        apply i_neq_j.
+        apply (f_equal (fun x => x + n)%nat) in in_eq_jn.
+        do 2 rewrite Nat.sub_add in in_eq_jn; auto.
       }
     }
   }
-Admitted.
+Qed.
 
 Lemma a6 : forall (P Q VP DP VQ DQ : Square 2) (V D : Square 4),
   WF_Unitary VP -> WF_Diagonal DP -> WF_Unitary VQ -> WF_Diagonal DQ ->

--- a/UnitaryMatrices.v
+++ b/UnitaryMatrices.v
@@ -10,6 +10,19 @@ From Proof Require Import Permutations.
 Require Import List.
 Import ListNotations.
 
+Lemma other_unitary_decomp : forall {n : nat} (U : Square n),
+  WF_Unitary U -> U × U† = I n.
+Proof.
+  intros n U Unitary_U.
+  assert (step : WF_Unitary U†).
+  {
+    apply adjoint_unitary, Unitary_U.
+  }
+  destruct step as [_ step].
+  rewrite <- step, adjoint_involutive.
+  reflexivity.
+Qed.
+
 Theorem a3 : forall {n} (U : Square n),
   WF_Unitary U -> exists (V D : Square n),
     (WF_Unitary V /\ WF_Diagonal D /\ U = V × D × V†).
@@ -259,24 +272,12 @@ Proof.
     {
       rewrite H, Mmult_adjoint.
       repeat rewrite <- Mmult_assoc.
-      assert (get_other_dagger : forall {n : nat} (U : Square n), WF_Unitary U -> U × U† = I n).
-      {
-        intros.
-        destruct Unitary_V.
-        assert (step : WF_Unitary U†).
-        {
-          apply adjoint_unitary; assumption.
-        }
-        destruct step as [_ step].
-        rewrite <- step, adjoint_involutive.
-        reflexivity.
-      }
       repeat rewrite Mmult_assoc.
       rewrite <- Mmult_assoc with (A := VP .⊕ VQ).
       replace 4%nat with (2 + 2)%nat by reflexivity.
-      rewrite get_other_dagger; auto.
+      rewrite other_unitary_decomp; auto.
       rewrite <- Mmult_assoc with (A := VP .⊕ VQ).
-      rewrite get_other_dagger; auto.
+      rewrite other_unitary_decomp; auto.
       rewrite adjoint_involutive.
       Msimpl_light; auto.
       destruct Unitary_V as [_ Unitary_V].

--- a/_CoqProject
+++ b/_CoqProject
@@ -10,6 +10,7 @@ QubitHelpers.v
 ExplicitDecompositions.v
 EigenvalueHelpers.v
 TraceoutHelpers.v
+Permutations.v
 
 # Appendix of proof
 SquareMatrices.v


### PR DESCRIPTION
Building off of the work in proving M3.2, we first refactor a bit and pull out permutation decomposition into a separate module. This cleans up the forwards proof for M3.2 drastically, and emphasizes that (by symmetry) we only really have two cases to handle.

TODO: In the forwards direction for M3.3, we use the fact that $\det(A) = \prod\mathrm{Eigenvalues}(A)$, which I don't believe is proven in QuantumLib. However, we can abuse Lemma A.1 to compute
```math
\begin{align*}
  \det(A) &= \det(UDU^\dagger) \\
&= \det(U)\det(D)\det(U^\dagger) \tag{Lemma A.1} \\
&= \det(U)\det(U^\dagger)\det(D) \\
&= \det(I)\det(D) \tag{Lemma A.1} \\
&= 1\cdot \det(D) \\
&= \det(D).
\end{align*}
```
In QuantumLib, we already have that $\det(I) = 1$ and $\det(D)$ is the product of the elements along the diagonal, so this should be sufficient to complete the proof.