### PR TITLE
refactor: Quite a few improvements/rewrites.

### DIFF
--- a/GateHelpers.v
+++ b/GateHelpers.v
@@ -78,7 +78,7 @@ Lemma ccu_sum_expansion : forall (U : Square 2),
 Proof.
   intros.
   unfold ccu.
-  rewrite control_decomp, (@direct_sum_decomp _ _ 0 0).
+  rewrite control_decomp.
   rewrite kron_assoc, id_kron.
   all: solve_WF_matrix.
 Qed.
@@ -89,7 +89,7 @@ Proof.
   intros.
   unfold swapab.
   unfold ccu.
-  repeat rewrite control_decomp, (@direct_sum_decomp _ _ 0 0).
+  repeat rewrite control_decomp.
   rewrite kron_plus_distr_l.
   repeat rewrite Mmult_plus_distr_l.
   repeat rewrite Mmult_plus_distr_r.

--- a/Main.v
+++ b/Main.v
@@ -517,11 +517,9 @@ Proof.
     }
     assert (step2 : (I 2 ⊗ P) × control (diag2 u0 u1) = P .⊕ PD).
     {
-      rewrite control_decomp.
-      repeat rewrite (direct_sum_decomp _ _ 2 2)%nat; auto.
+      rewrite control_decomp, (direct_sum_decomp _ _ 0 0).
       rewrite Mmult_plus_distr_l.
       repeat rewrite kron_mixed_product; Msimpl_light.
-      reflexivity.
       all: solve_WF_matrix.
     }
     pose proof (a3 P Unitary_P) as [VP [DP [Unitary_VP [Diagonal_DP P_decomp]]]].
@@ -1014,7 +1012,7 @@ Proof.
   - intros [U [V [P0 [P1 [Q0 [Q1 [Unitary_U [Unitary_V [Unitary_P0 [Unitary_P1 [Unitary_Q0 [Unitary_Q1 H1]]]]]]]]]]]].
     rewrite <- (direct_sum_decomp _ _ 0 0) in H1; solve_WF_matrix.
     unfold ccu in H1.
-    rewrite control_decomp in H1.
+    rewrite control_direct_sum in H1.
     assert (H2 : (U × (P0 ⊗ Q0) × V) = I 4 /\ (U × (P1 ⊗ Q1) × V) = control (diag2 u0 u1)).
     {
       apply direct_sum_simplify; solve_WF_matrix.
@@ -1066,12 +1064,14 @@ Proof.
       rewrite id_kron.
       Msimpl_light.
       unfold ccu.
-      rewrite control_decomp, <- (direct_sum_decomp _ _ 0 0); solve_WF_matrix.
+      rewrite <- (direct_sum_decomp _ _ 0 0); solve_WF_matrix.
+      rewrite control_direct_sum.
       rewrite direct_sum_simplify; solve_WF_matrix.
-      split; try reflexivity.
-      (* PERF: Can probably be sped up by omitting lma' *)
-      lma'; solve_WF_matrix.
-      all: unfold notc, Mmult, diag2, control, kron; simpl; Csimpl; reflexivity.
+      split. reflexivity.
+      lma'.
+      (* TODO: Why doesn't solve_WF_matrix work? *)
+      apply (WF_control 2), WF_diag2.
+      all: unfold diag2, control, kron; simpl; Csimpl; reflexivity.
     + exists notc, notc, (I 2), (diag2 1 u0), (I 2), (diag2 1 u1).
       split. apply notc_unitary.
       split. apply notc_unitary.
@@ -1079,15 +1079,16 @@ Proof.
       split. apply diag2_unitary; auto; apply Cmod_1.
       split. apply id_unitary.
       split. apply diag2_unitary; auto; apply Cmod_1.
-      rewrite id_kron.
-      Msimpl_light.
-      rewrite notc_notc.
+      rewrite id_kron, Mmult_1_r.
+      rewrite notc_notc at 1.
       unfold ccu.
-      rewrite control_decomp, <- (direct_sum_decomp _ _ 0 0); solve_WF_matrix.
-      rewrite direct_sum_simplify; solve_WF_matrix.
-      split; try reflexivity.
+      rewrite <- (direct_sum_decomp _ _ 0 0).
+      rewrite control_direct_sum.
+      rewrite direct_sum_simplify.
+      split. reflexivity.
       (* PERF: Can probably be sped up by omitting lma' *)
-      lma'; solve_WF_matrix.
+      lma'.
+      all: solve_WF_matrix.
       all: unfold notc, Mmult, diag2, control, kron; simpl; Csimpl; auto.
 Qed.
 
@@ -1486,8 +1487,7 @@ Proof.
     assert (ccdiag_decomp : ccu (diag2 u0 u1) = ∣0⟩⟨0∣ ⊗ (I 4) .+ ∣1⟩⟨1∣ ⊗ (control (diag2 u0 u1))).
     {
       unfold ccu.
-      rewrite control_decomp.
-      rewrite <- (direct_sum_decomp _ _ 0 0); solve_WF_matrix.
+      rewrite control_decomp; solve_WF_matrix.
     }
     rewrite ccdiag_decomp in H0.
     pose proof (
@@ -1634,7 +1634,7 @@ Proof.
       Msimpl_light.
       rewrite id_kron; Msimpl_light.
       unfold ccu.
-      do 2 rewrite control_decomp.
+      do 2 rewrite control_direct_sum.
       (* TODO: prove kron distributes over direct sums *)
       repeat rewrite (direct_sum_decomp _ _ 0 0); solve_WF_matrix.
       rewrite kron_plus_distr_r.
@@ -1700,7 +1700,7 @@ Proof.
       split.
       {
         unfold V.
-        rewrite control_decomp, (direct_sum_decomp _ _ 0 0); solve_WF_matrix.
+        rewrite control_decomp; solve_WF_matrix.
       }
       {
         assert (step1 : P = (/ u) .* ∣0⟩⟨0∣ .+ u .* ∣1⟩⟨1∣).
@@ -1730,7 +1730,7 @@ Proof.
         assert (step3 : acgate V = ∣0⟩⟨0∣ ⊗ I 4 .+ ∣1⟩⟨1∣ ⊗ I 2 ⊗ P).
         {
           unfold acgate, abgate, swapbc, V.
-          rewrite control_decomp, (direct_sum_decomp _ _ 0 0); solve_WF_matrix.
+          rewrite control_decomp; solve_WF_matrix.
           rewrite kron_plus_distr_r.
           rewrite kron_assoc; solve_WF_matrix.
           rewrite kron_assoc; solve_WF_matrix.
@@ -1776,7 +1776,7 @@ Proof.
           rewrite cancel00, cancel01, cancel10, cancel11.
           Msimpl_light.
           rewrite step4.
-          rewrite control_decomp, (@direct_sum_decomp _ _ 0 0).
+          rewrite control_decomp.
           reflexivity.
           all: solve_WF_matrix.
         }
@@ -1830,7 +1830,7 @@ Proof.
         repeat rewrite kron_assoc.
         rewrite <- (kron_plus_distr_l 2 2 4 4).
         rewrite <- (@direct_sum_decomp _ _ 0 0).
-        rewrite control_decomp.
+        rewrite control_direct_sum.
         reflexivity.
         all: solve_WF_matrix.
       }

--- a/Main.v
+++ b/Main.v
@@ -1635,13 +1635,7 @@ Proof.
       rewrite id_kron; Msimpl_light.
       unfold ccu.
       do 2 rewrite control_direct_sum.
-      (* TODO: prove kron distributes over direct sums *)
-      repeat rewrite (direct_sum_decomp _ _ 0 0); solve_WF_matrix.
-      rewrite kron_plus_distr_r.
-      rewrite kron_assoc with (C := I 2); solve_WF_matrix.
-      rewrite kron_assoc with (C := I 2); solve_WF_matrix.
-      repeat rewrite <- (direct_sum_decomp 4 4 0 0); solve_WF_matrix.
-
+      rewrite kron_direct_sum_distr_r with (A := I 2) at 1; solve_WF_matrix.
       rewrite direct_sum_simplify; solve_WF_matrix.
       split. rewrite id_kron; reflexivity.
       lma'; solve_WF_matrix.

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ CoqMakefile: Makefile _CoqProject
 	$(COQBIN) coq_makefile -f _CoqProject -o CoqMakefile
 
 invoke-coqmakefile: CoqMakefile
-	$(MAKE) --no-print-directory -f CoqMakefile $(filter-out $(KNOWNTARGETS),$(MAKECMDGOALS))
+	$(MAKE) --no-print-directory -f CoqMakefile $(filter-out $(KNOWNTARGETS),$(MAKECMDGOALS)) -j
 
 .PHONY: invoke-coqmakefile $(KNOWNFILES)
 

--- a/MatrixHelpers.v
+++ b/MatrixHelpers.v
@@ -2268,7 +2268,7 @@ rewrite H.
 apply kron_plus_distr_r.
 Qed.
 
-Lemma control_decomp : forall {n} (A : Square n), control A = I n .⊕ A.
+Lemma control_direct_sum : forall {n} (A : Square n), control A = I n .⊕ A.
 Proof.
   intros.
   prep_matrix_equality.
@@ -2321,6 +2321,14 @@ Proof.
       lca.
     }
   }
+Qed.
+
+Lemma control_decomp : forall {n} (A : Square n),
+  WF_Matrix A -> control A = ∣0⟩⟨0∣ ⊗ I n .+ ∣1⟩⟨1∣ ⊗ A.
+Proof.
+  intros.
+  rewrite control_direct_sum, (@direct_sum_decomp _ _ 0 0).
+  all: solve_WF_matrix.
 Qed.
 
 Lemma direct_sum_simplify : forall {n} (A B C D : Square n),

--- a/MatrixHelpers.v
+++ b/MatrixHelpers.v
@@ -36,6 +36,16 @@ Proof.
   assumption.
 Qed.
 
+Lemma kron_direct_sum_distr_r : forall {m n o p} (A B : Matrix m n) (C : Matrix o p),
+  WF_Matrix A -> WF_Matrix B -> WF_Matrix C -> (A .⊕ B) ⊗ C = (A ⊗ C) .⊕ (B ⊗ C).
+Proof.
+  intros.
+  repeat rewrite (direct_sum_decomp _ _ 0 0).
+  rewrite (kron_plus_distr_r (2 * m) (2 * n) o p (∣0⟩⟨0∣ ⊗ A) (∣1⟩⟨1∣ ⊗ B) C) at 1.
+  repeat rewrite <- kron_assoc.
+  all: solve_WF_matrix.
+Qed.
+
 Definition diag2 (c1 c2 : C) : Square 2 :=
   fun x y =>
     match (x,y) with

--- a/MatrixHelpers.v
+++ b/MatrixHelpers.v
@@ -427,9 +427,7 @@ Lemma WF_blockmatrix {n}: forall (P00 P01 P10 P11: Square n),
   WF_Matrix (∣0⟩⟨0∣ ⊗ P00 .+ ∣0⟩⟨1∣ ⊗ P01 .+ ∣1⟩⟨0∣ ⊗ P10 .+ ∣1⟩⟨1∣ ⊗ P11).
 Proof.
   intros.
-  repeat apply WF_plus; auto.
-  all: try apply WF_kron; auto.
-  all: show_wf.
+  solve_WF_matrix.
 Qed.
 
 Lemma isolate_inner_mult {a b c d e}: forall (A: Matrix a b) (B: Matrix b c) (C: Matrix c d) (D: Matrix d e),
@@ -448,13 +446,17 @@ Lemma block_multiply {n}: forall (U V: Square (2*n)%nat) (P00 P01 P10 P11 Q00 Q0
   U × V = ∣0⟩⟨0∣ ⊗ (P00 × Q00 .+ P01 × Q10) .+ ∣0⟩⟨1∣ ⊗ (P00 × Q01 .+ P01×Q11) .+ ∣1⟩⟨0∣ ⊗ (P10×Q00 .+ P11 × Q10) .+ ∣1⟩⟨1∣ ⊗ (P10 × Q01 .+ P11 × Q11).
 Proof.
   intros.
-  rewrite H7, H8.
+  rewrite H7, H8; clear H7 H8.
   repeat rewrite Mmult_plus_distr_l.
   repeat rewrite Mmult_plus_distr_r.
   repeat rewrite kron_mixed_product.
-  repeat rewrite isolate_inner_mult.
-  rewrite Mmult00, Mmult01, Mmult10, Mmult11.
-  solve_matrix.
+  repeat rewrite cancel00.
+  repeat rewrite cancel01.
+  repeat rewrite cancel10.
+  repeat rewrite cancel11.
+  Msimpl_light.
+  lma'.
+  all: solve_WF_matrix.
 Qed.
 
 Lemma upper_left_block_entries {n}: forall (A : Square n) (i j: nat),

--- a/Swaps.v
+++ b/Swaps.v
@@ -45,7 +45,7 @@ Proof.
   intros.
   unfold swapbc.
   unfold ccu.
-  rewrite control_decomp, (@direct_sum_decomp _ _ 0 0).
+  rewrite control_decomp.
   rewrite Mmult_plus_distr_l.
   rewrite Mmult_plus_distr_r.
   repeat rewrite kron_mixed_product.

--- a/UnitaryMatrices.v
+++ b/UnitaryMatrices.v
@@ -149,26 +149,26 @@ Lemma direct_sum_unitary : forall {n : nat} (P Q : Square n),
 Proof.
   intros n P Q [WF_P Unitary_P] [WF_Q Unitary_Q].
   unfold WF_Unitary.
-  split; try apply WF_direct_sum; auto.
-  repeat rewrite direct_sum_decomp; auto.
+  split. apply WF_direct_sum; auto.
+  rewrite direct_sum_decomp; auto.
   replace (n + n)%nat with (2 * n)%nat by lia.
   rewrite Mplus_adjoint.
-  repeat rewrite Mmult_plus_distr_r.
+  rewrite Mmult_plus_distr_r.
   repeat rewrite Mmult_plus_distr_l.
   repeat rewrite kron_adjoint.
   repeat rewrite kron_mixed_product.
-  replace ∣0⟩⟨0∣† with ∣0⟩⟨0∣ by lma'.
-  replace ∣1⟩⟨1∣† with ∣1⟩⟨1∣ by lma'.
-  repeat rewrite cancel00; auto with wf_db.
-  repeat rewrite cancel11; auto with wf_db.
-  repeat rewrite cancel01; Msimpl_light.
-  repeat rewrite cancel10; Msimpl_light.
+  rewrite adjoint00, adjoint11.
+  rewrite cancel00, cancel01, cancel10, cancel11; solve_WF_matrix.
+  repeat rewrite kron_0_l.
+  rewrite Mplus_0_l, Mplus_0_r.
   rewrite Unitary_P, Unitary_Q.
   rewrite <- kron_plus_distr_r.
   rewrite Mplus01.
   rewrite id_kron.
   reflexivity.
 Qed.
+
+#[export] Hint Resolve direct_sum_unitary : unit_db.
 
 Lemma direct_sum_diagonal : forall {n : nat} (P Q : Square n),
   WF_Diagonal P -> WF_Diagonal Q -> WF_Diagonal (P .⊕ Q).

--- a/WFHelpers.v
+++ b/WFHelpers.v
@@ -29,8 +29,8 @@ Ltac solve_WF_matrix :=
       | |- WF_Unitary (adjoint _) => apply adjoint_unitary
       | |- WF_Unitary (Mopp _) => unfold Mopp
       | |- WF_Unitary (_ × _) => apply Mmult_unitary
-      (* TODO: Make this lemma *)
-      (*| |- WF_Unitary (_ .⊕ _) => apply direct_sum_unitary; try lia*)
+      (* TODO: Upstream `direct_sum_unitary`, otherwise we can't have this case *)
+      (*| |- WF_Unitary (_ .⊕ _) => apply direct_sum_unitary *)
       | [ A : Square ?m, B : Square ?n  |- WF_Unitary (?A ⊗ ?B) ] => apply (@kron_unitary m n)
       | [ A : Square ?n |- WF_Unitary (control ?A) ] => apply (@control_unitary n)
       | |- WF_Unitary ?A => match goal with

--- a/WFHelpers.v
+++ b/WFHelpers.v
@@ -12,7 +12,9 @@ Ltac solve_WF_matrix :=
       try reflexivity;
       try assumption;
       try match goal with
-      | [ A : Square ?n |- WF_Matrix (control ?A) ] => apply (@WF_control n)
+      | |- WF_Matrix (control ?A) => match type of A with
+                                     | Square ?n => apply (@WF_control n)
+                                     end
       | |- WF_Matrix (adjoint _) => apply WF_adjoint
       | |- WF_Matrix (Mopp _) => unfold Mopp
       | |- WF_Matrix (_ .+ _) => apply WF_plus; try lia
@@ -31,8 +33,14 @@ Ltac solve_WF_matrix :=
       | |- WF_Unitary (_ × _) => apply Mmult_unitary
       (* TODO: Upstream `direct_sum_unitary`, otherwise we can't have this case *)
       (*| |- WF_Unitary (_ .⊕ _) => apply direct_sum_unitary *)
-      | [ A : Square ?m, B : Square ?n  |- WF_Unitary (?A ⊗ ?B) ] => apply (@kron_unitary m n)
-      | [ A : Square ?n |- WF_Unitary (control ?A) ] => apply (@control_unitary n)
+      | |- WF_Unitary (?A ⊗ ?B) => match type of A with
+                                     | Square ?m => match type of B with
+                                                    | Square ?n => apply (@kron_unitary m n)
+                                                    end
+                                     end
+      | |- WF_Unitary (control ?A) => match type of A with
+                                      | Square ?n => apply (@control_unitary n)
+                                      end
       | |- WF_Unitary ?A => match goal with
                             | [ H : WF_Unitary A |- _ ] => apply H
                             | _ => auto with unit_db; autounfold with M_db; try unfold A


### PR DESCRIPTION
Renaming `control_decomp` to `control_direct_sum`, reserving `*_decomp` for Lemmas that decompose a matrix into the form `|0><0| tens A .+ |1><1| tens B`. Also proves a new lemma `control_decomp`.